### PR TITLE
Fix comment typo in configuration file and add fetch handler tests

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,52 @@
+import handler from "../src/index";
+import { describe, it, expect, vi } from "vitest";
+
+// Utility to create Env with mocks
+function createEnv(options: {
+  assetResponse?: Response;
+  aiResponse?: Response;
+} = {}) {
+  const assetResponse = options.assetResponse || new Response("asset", { status: 200 });
+  const aiResponse = options.aiResponse || new Response("ai", { status: 200 });
+  const env = {
+    ASSETS: { fetch: vi.fn().mockResolvedValue(assetResponse) },
+    AI: { run: vi.fn().mockResolvedValue(aiResponse) },
+  } as any;
+  return { env, assetResponse, aiResponse };
+}
+
+describe("fetch handler", () => {
+  it("serves static assets for root path", async () => {
+    const { env, assetResponse } = createEnv();
+    const request = new Request("https://example.com/");
+    const res = await handler.fetch(request, env, {} as ExecutionContext);
+    expect(env.ASSETS.fetch).toHaveBeenCalledOnce();
+    expect(res).toBe(assetResponse);
+  });
+
+  it("returns 405 for non-POST to /api/chat", async () => {
+    const { env } = createEnv();
+    const request = new Request("https://example.com/api/chat", { method: "GET" });
+    const res = await handler.fetch(request, env, {} as ExecutionContext);
+    expect(res.status).toBe(405);
+  });
+
+  it("calls AI.run for POST /api/chat and returns result", async () => {
+    const { env, aiResponse } = createEnv();
+    const body = { messages: [{ role: "user", content: "hi" }] };
+    const request = new Request("https://example.com/api/chat", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    const res = await handler.fetch(request, env, {} as ExecutionContext);
+    expect(env.AI.run).toHaveBeenCalledOnce();
+    expect(res).toBe(aiResponse);
+  });
+
+  it("returns 404 for unknown API routes", async () => {
+    const { env } = createEnv();
+    const request = new Request("https://example.com/api/unknown");
+    const res = await handler.fetch(request, env, {} as ExecutionContext);
+    expect(res.status).toBe(404);
+  });
+});

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -6540,7 +6540,7 @@ declare module "cloudflare:pipelines" {
         protected ctx: ExecutionContext;
         constructor(ctx: ExecutionContext, env: Env);
         /**
-         * run recieves an array of PipelineRecord which can be
+        * run receives an array of PipelineRecord which can be
          * transformed and returned to the pipeline
          * @param records Incoming records from the pipeline to be transformed
          * @param metadata Information about the specific pipeline calling the transformation entrypoint


### PR DESCRIPTION
## Summary
- correct spelling in `PipelineTransformationEntrypoint` JSDoc comment
- add Vitest tests covering static asset handling and chat API routes

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688890accfe8832b8b0ea12489a68cd4